### PR TITLE
Update import path in test_task.py (EDC-913)

### DIFF
--- a/page_object/first_tests_with_po/elements/tests/test_task.py
+++ b/page_object/first_tests_with_po/elements/tests/test_task.py
@@ -4,7 +4,7 @@ import pytest
 from _pytest.config import ExitCode
 from selenium.webdriver.common.by import By
 
-from page_object.first_tests_with_po.elements.pages.locators import MainPageLocators
+from page_object.first_tests_with_po.task.pages.locators import MainPageLocators
 
 
 class TestCase(unittest.TestCase):


### PR DESCRIPTION
The import path to MainPageLocators in test_task.py was not resolved due to Framework Lesson Learner mode path specifics (the folder the learner uses is allways called "task") and has been updated.

https://youtrack.jetbrains.com/issue/EDC-913